### PR TITLE
feat: Preserve the crafting speed bonuses

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,9 @@
 ---------------------------------------------------------------------------------------------------
+Version: 3.5.2
+Date: 2025-07-28
+  Changes:
+    - Updated the Crafting Speed slider to increase the crafting speed instead of setting it directly.
+---------------------------------------------------------------------------------------------------
 Version: 3.5.1
 Date: 2025-07-27
   Bugfixes:

--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
   "name": "factorio-admin-command-center",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "title": "Factorio Admin Command Center",
   "author": "louanbastos",
   "contact": "https://github.com/louanfontenele",

--- a/locale/en/facc.cfg
+++ b/locale/en/facc.cfg
@@ -181,8 +181,8 @@ set-game-speed-msg=Game speed set to %s
 set-mining-speed=Set Mining Speed
 set-mining-speed-msg=Mining speed set to %s
 
-set-crafting-speed=Set Crafting Speed
-set-crafting-speed-msg=Crafting speed set to %s
+set-crafting-speed=Increase Crafting Speed
+set-crafting-speed-msg=Crafting speed increased by %s
 
 generate-planet-surfaces=Generate Planets Surfaces and Chart Area (Space Age)
 generate-planet-surfaces-msg=Planet surfaces generated and charted

--- a/locale/pt-BR/facc.cfg
+++ b/locale/pt-BR/facc.cfg
@@ -181,8 +181,8 @@ set-game-speed-msg=Velocidade do jogo ajustada para %s
 set-mining-speed=Definir Velocidade de Mineração
 set-mining-speed-msg=Velocidade de mineração ajustada para %s
 
-set-crafting-speed=Definir Velocidade de Fabricação
-set-crafting-speed-msg=Velocidade de fabricação ajustada para %s
+set-crafting-speed=Aumentar Velocidade de Fabricação
+set-crafting-speed-msg=Velocidade de fabricação aumentada em %s
 
 generate-planet-surfaces=Gerar Superfícies dos Planetas e Mapear Área (Era Espacial)
 generate-planet-surfaces-msg=Superfícies dos planetas geradas e mapeadas

--- a/scripts/events/gui_events.lua
+++ b/scripts/events/gui_events.lua
@@ -235,6 +235,17 @@ script.on_event(defines.events.on_gui_value_changed, function(event)
     return
   end
 
+  -- Handle Set Crafting Speed as a true live slider
+  if elem.name == "slider_set_crafting_speed" then
+    local old = storage.facc_gui_state.sliders["slider_set_crafting_speed"] or 0
+    local new = elem.slider_value
+    set_crafting_speed.run(player, old, new)
+    storage.facc_gui_state.sliders["slider_set_crafting_speed"] = new
+    local box = elem.parent[elem.name .. "_value"]
+    if box and box.valid then box.text = tostring(new) end
+    return
+  end
+
   -- Default behavior for other sliders
   storage.facc_gui_state.sliders[elem.name] = elem.slider_value
   local box = elem.parent[elem.name .. "_value"]
@@ -246,9 +257,6 @@ script.on_event(defines.events.on_gui_value_changed, function(event)
     local speed = speeds[idx] or 1
     set_game_speed.run(player, speed)
     if box and box.valid then box.text = tostring(speed) end
-
-  elseif elem.name == "slider_set_crafting_speed" then
-    set_crafting_speed.run(player, elem.slider_value)
 
   elseif elem.name == "slider_set_mining_speed" then
     set_mining_speed.run(player, elem.slider_value)

--- a/scripts/manufacturing/set_crafting_speed.lua
+++ b/scripts/manufacturing/set_crafting_speed.lua
@@ -1,23 +1,31 @@
--- File: scripts/manufacturing/set_crafting_speed.lua
--- Allows admins to set manual crafting speed modifier via slider.
--- @param player LuaPlayer      — the invoking player
--- @param modifier number       — crafting speed modifier (0..1000)
+-- scripts/manufacturing/set_crafting_speed.lua
+-- Live slider: adjusts manual crafting speed modifier via slider.
 local M = {}
 
---- Runs the crafting speed change.
--- Checks permissions, clamps the value, applies and notifies the player.
--- @param player LuaPlayer
--- @param modifier number
-function M.run(player, modifier)
+--- Applies a new slider-based manual crafting speed modifier.
+-- It removes the previous slider modifier and applies the new one,
+-- ensuring that existing (e.g. research) modifiers are preserved.
+-- @param player LuaPlayer — the invoking player
+-- @param old number       — the previous modifier value applied by the slider
+-- @param new number       — the new slider modifier to apply
+function M.run(player, old, new)
   if not is_allowed(player) then
     player.print({"facc.not-allowed"})
     return
   end
-  -- Clamp between 0 and 1000
-  local m = math.max(0, math.min(modifier, 1000))
+
   local force = player.force
-  force.manual_crafting_speed_modifier = m
-  -- player.print({"facc.set-crafting-speed-msg", m})
+  local current = force.manual_crafting_speed_modifier or 0
+
+  -- Remove old slider effect, preserving any existing modifiers (e.g. from research)
+  local base = current - old
+
+  -- Clamp between 0 and 1000
+  local slider_bonus = math.max(0, math.min(new, 1000))
+  force.manual_crafting_speed_modifier = base + slider_bonus
+
+  -- Apply base + new slider bonus
+  force.manual_crafting_speed_modifier = base + slider_bonus
 end
 
 return M


### PR DESCRIPTION
This change will take into account the manual crafting speed bonuses of the character (for example, from researchs of external mods). It will add the specified bonus instead of setting it.